### PR TITLE
make 1 min height of mux wrapper

### DIFF
--- a/gemstone/common/mux_wrapper.py
+++ b/gemstone/common/mux_wrapper.py
@@ -38,7 +38,7 @@ class MuxWrapper(Generator):
     def __init__(self, height, width, name=None):
         super().__init__(name)
 
-        self.height = height
+        self.height = max(height, 1)
         self.width = width
 
         T = magma.Bits[self.width]


### PR DESCRIPTION
Canal tries to create muxes of height 0 in some cases, and muxes of height one in others, which was causing tiles to be uniquified unnecessarily. Since muxes of height 0 and 1 correspond to the same circuit (a pass through wire), we can prevent the uniquification by setting the height to 1 when the input height parameter is less than 1.