### PR TITLE
Add target_module and type_map to gemstone FromVerilog function

### DIFF
--- a/gemstone/generator/from_verilog.py
+++ b/gemstone/generator/from_verilog.py
@@ -3,6 +3,6 @@ from .from_magma import *
 
 
 class FromVerilog(FromMagma):
-    def __init__(self, filename, target_modules=none, type_map={}):
+    def __init__(self, filename, target_modules=None, type_map={}):
         underlying = magma.DefineFromVerilogFile(filename, target_modules, type_map)[0]
         super().__init__(underlying)

--- a/gemstone/generator/from_verilog.py
+++ b/gemstone/generator/from_verilog.py
@@ -3,6 +3,6 @@ from .from_magma import *
 
 
 class FromVerilog(FromMagma):
-    def __init__(self, filename):
-        underlying = magma.DefineFromVerilogFile(filename)[0]
+    def __init__(self, filename, target_modules=none, type_map={}):
+        underlying = magma.DefineFromVerilogFile(filename, target_modules, type_map)[0]
         super().__init__(underlying)


### PR DESCRIPTION
Brings the target_modules and type_map arguments from Magma's DefineFromVerilog function up to Gemstone's DefineFromVerilog.

I'd like to be able to target a specific module from a single file with multiple module definitions.