### PR TITLE
Add remove port

### DIFF
--- a/gemstone/generator/generator.py
+++ b/gemstone/generator/generator.py
@@ -24,9 +24,8 @@ class Generator(ABC):
             raise ValueError(f"{name} is already a port")
         self.ports[name] = PortReference(self, name, T)
 
-    def remove_port(self, port: PortReference):
+    def remove_port(self, port_name: str):
         # first remove it from self.ports
-        port_name = port._name
         assert port_name in self.ports
         self.ports.pop(port_name)
         # then remove any wires connected with it. due to port cloning

--- a/gemstone/generator/generator.py
+++ b/gemstone/generator/generator.py
@@ -24,6 +24,22 @@ class Generator(ABC):
             raise ValueError(f"{name} is already a port")
         self.ports[name] = PortReference(self, name, T)
 
+    def remove_port(self, port: PortReference):
+        # first remove it from self.ports
+        port_name = port._name
+        assert port_name in self.ports
+        self.ports.pop(port_name)
+        # then remove any wires connected with it. due to port cloning
+        # the only thing won't change is the port name
+        wires_to_remove = set()
+        for conn1, conn2 in self.wires:
+            if conn1._name == port_name:
+                wires_to_remove.add((conn1, conn2))
+            elif conn2._name == port_name:
+                wires_to_remove.add((conn1, conn2))
+        for conn1, conn2 in wires_to_remove:
+            self.remove_wire(conn1, conn2)
+
     def add_ports(self, **kwargs):
         for name, T in kwargs.items():
             self.add_port(name, T)

--- a/gemstone/generator/generator.py
+++ b/gemstone/generator/generator.py
@@ -32,9 +32,9 @@ class Generator(ABC):
         # the only thing won't change is the port name
         wires_to_remove = set()
         for conn1, conn2 in self.wires:
-            if conn1._name == port_name:
+            if conn1._name == port_name and conn1.owner() == self:
                 wires_to_remove.add((conn1, conn2))
-            elif conn2._name == port_name:
+            elif conn2._name == port_name and conn2.owner() == self:
                 wires_to_remove.add((conn1, conn2))
         for conn1, conn2 in wires_to_remove:
             self.remove_wire(conn1, conn2)

--- a/tests/generator/test_generator.py
+++ b/tests/generator/test_generator.py
@@ -1,0 +1,26 @@
+from gemstone.generator.generator import *
+import magma
+
+
+def test_remove_port():
+    width = 16
+
+    class Gen(Generator):
+        def __init__(self):
+            super().__init__()
+            self.add_ports(
+                port0=magma.In(magma.Bits[width + 1]),
+                port1=magma.Out(magma.Bits[width + 1]),
+            )
+
+            self.wire(self.ports.port0, self.ports.port1)
+
+        def name(self):
+            return "TestGen"
+
+    gen = Gen()
+    assert len(gen.wires) == 1
+    # now remove it
+    gen.remove_port(gen.ports.port0)
+    assert "port0" not in gen.ports
+    assert len(gen.wires) == 0

--- a/tests/generator/test_generator.py
+++ b/tests/generator/test_generator.py
@@ -5,22 +5,38 @@ import magma
 def test_remove_port():
     width = 16
 
+    class Child(Generator):
+        def __init__(self):
+            super().__init__()
+            self.add_ports(
+                port0_=magma.In(magma.Bits[width + 1]),
+                port0=magma.Out(magma.Bits[width + 1]),
+            )
+
+            self.wire(self.ports.port0_, self.ports.port0)
+
+        def name(self):
+            return "Child"
+
     class Gen(Generator):
         def __init__(self):
             super().__init__()
             self.add_ports(
                 port0=magma.In(magma.Bits[width + 1]),
-                port1=magma.Out(magma.Bits[width + 1]),
+                port1=magma.In(magma.Bits[width + 1]),
+                port2=magma.Out(magma.Bits[width + 1]),
             )
+            child = Child()
 
-            self.wire(self.ports.port0, self.ports.port1)
+            self.wire(self.ports.port0, child.ports.port0_)
+            self.wire(self.ports.port1, child.ports.port0)
 
         def name(self):
             return "TestGen"
 
     gen = Gen()
-    assert len(gen.wires) == 1
+    assert len(gen.wires) == 2
     # now remove it
     gen.remove_port("port0")
     assert "port0" not in gen.ports
-    assert len(gen.wires) == 0
+    assert len(gen.wires) == 1

--- a/tests/generator/test_generator.py
+++ b/tests/generator/test_generator.py
@@ -21,6 +21,6 @@ def test_remove_port():
     gen = Gen()
     assert len(gen.wires) == 1
     # now remove it
-    gen.remove_port(gen.ports.port0)
+    gen.remove_port("port0")
     assert "port0" not in gen.ports
     assert len(gen.wires) == 0


### PR DESCRIPTION
Allow port to be removed from the generator. This is needed for global buffer remove ports added in `canal`  and add more ports.