### PR TITLE
Fix parameter mapping error

### DIFF
--- a/gemstone/common/genesis_wrapper.py
+++ b/gemstone/common/genesis_wrapper.py
@@ -45,9 +45,11 @@ class GenesisWrapper:
                     "consistent")
             parameters = {}
             for param, (_, default) in self.__interface.params.items():
-                if param_mapping is not None and param in param_mapping:
-                    param = param_mapping[param]
-                parameters[param] = kwargs.get(param, default)
+		if param_mapping is not None and param in param_mapping:
+                    parameters[param_mapping[param]] = \
+                            kwargs.get(param, default)
+                else:
+                    parameters[param] = kwargs.get(param, default)
 
             # Allow user to override default input_files
             infiles = kwargs.get("infiles", self.__default_infiles)

--- a/gemstone/common/genesis_wrapper.py
+++ b/gemstone/common/genesis_wrapper.py
@@ -45,7 +45,7 @@ class GenesisWrapper:
                     "consistent")
             parameters = {}
             for param, (_, default) in self.__interface.params.items():
-		if param_mapping is not None and param in param_mapping:
+                if param_mapping is not None and param in param_mapping:
                     parameters[param_mapping[param]] = \
                             kwargs.get(param, default)
                 else:


### PR DESCRIPTION
There was a bug when passing parameter from generator to genesis, if it is using `param_mapping`.
It should first parse `kwargs` to read data from `generator param` and map that data to `genesis parameter`.
It was parsing `kwargs` with `genesis parameter`, instead, so generator parameters were not passed down to genesis.