### PR TITLE
Add core info that tells PnR about the layout

### DIFF
--- a/gemstone/common/core.py
+++ b/gemstone/common/core.py
@@ -7,6 +7,25 @@ from typing import List, Union
 import mantle
 
 
+class PnRTag:
+    def __init__(self, tag_name: str, priority_major: int,
+                 priority_minor: int):
+        assert len(tag_name) == 1, "Tag can only be one character"
+        self.tag_name = tag_name
+        self.priority_major = priority_major
+        self.priority_minor = priority_minor
+
+    def __eq__(self, other):
+        if not isinstance(other, PnRTag):
+            return False
+        return self.tag_name == other.tag_name \
+            and self.priority_major == self.priority_major \
+            and self.priority_minor == self.priority_minor
+
+    def __hash__(self):
+        return hash(self.tag_name)
+
+
 class Core(Generator):
     DEFAULT_PRIORITY = 20
     @abstractmethod
@@ -20,11 +39,12 @@ class Core(Generator):
     def features(self) -> List[Union["Core", "CoreFeature"]]:
         return [self]
 
-    def pnr_info(self):
+    def pnr_info(self) -> Union[PnRTag, List[PnRTag]]:
         tag = self.name()[0]
         priority_major = self.DEFAULT_PRIORITY
         priority_minor = self.DEFAULT_PRIORITY
-        return tag, (priority_major, priority_minor)
+        # this can be a list as well
+        return PnRTag(tag, priority_major, priority_minor)
 
 
 class ConfigurableCore(Core, Configurable):

--- a/gemstone/common/core.py
+++ b/gemstone/common/core.py
@@ -8,6 +8,7 @@ import mantle
 
 
 class Core(Generator):
+    DEFAULT_PRIORITY = 20
     @abstractmethod
     def inputs(self):
         pass
@@ -18,6 +19,12 @@ class Core(Generator):
 
     def features(self) -> List[Union["Core", "CoreFeature"]]:
         return [self]
+
+    def pnr_info(self):
+        tag = self.name()[0]
+        priority_major = self.DEFAULT_PRIORITY
+        priority_minor = self.DEFAULT_PRIORITY
+        return tag, (priority_major, priority_minor)
 
 
 class ConfigurableCore(Core, Configurable):


### PR DESCRIPTION
This will remove the hard-coded info in `pnr_info` dump. `garnet` will use this info to produce matching netlist.