### PR TITLE
More advanced replace pass

### DIFF
--- a/gemstone/common/transform.py
+++ b/gemstone/common/transform.py
@@ -1,8 +1,10 @@
-from .mux_with_default import MuxWithDefaultWrapper
 from ..generator.from_magma import FromMagma
-from ..generator.generator import Generator
+from ..generator.generator import Generator, PortReference
 import magma
 import mantle
+from typing import List, Union, Iterable, Tuple
+from ordered_set import OrderedSet
+from collections import OrderedDict
 
 
 def pass_signal_through(gen: Generator, signal):
@@ -52,29 +54,90 @@ def or_reduction(gen: Generator, sub_circuit_name: str, signal_name: str,
     return gen.ports[input_name]
 
 
-def replace(parent: Generator, old_gen: Generator, new_gen: Generator):
+def __get_external_ports(parent: Generator, generators: List[Generator],
+                         ignored_ports: List[PortReference]):
+    # we use a (name, id) pair because there may be duplicated names
+    # in internal connections.
+    # for instance, say we have three generators gen_1, gen_2, gen3,
+    # their internal connections are
+    # gen_1.O -> gen_2.I and gen_2.O -> gen_2.I
+    ports = OrderedSet()
+    # since generator is not hashable, we will use its id instead
+    id_to_owner = {}
+    for gen in generators:
+        for port in gen.ports.values():
+            owner_id = id(port.owner())
+            port_name = port.qualified_name()
+            if port in ignored_ports:
+                continue
+            ports.add((port_name, owner_id))
+            id_to_owner[owner_id] = port.owner()
+
+    # remove them if one of the port is connected
+    for conn1, conn2 in parent.wires:
+        conn1_name = conn1.qualified_name()
+        conn2_name = conn2.qualified_name()
+        conn1_id = id(conn1.owner())
+        conn2_id = id(conn2.owner())
+        conn1_entry = conn1_name, conn1_id
+        conn2_entry = conn2_name, conn2_id
+        if conn1_entry in ports and conn2_entry in ports:
+            ports.remove(conn1_entry)
+            ports.remove(conn2_entry)
+    # notice that these external ports have to be unique as a group
+    result = OrderedDict()
+    result_ids = set()
+    for port_name, owner_id in ports:
+        assert port_name not in result, "External ports have to be unique"
+        result[port_name] = id_to_owner[owner_id]
+        result_ids.add(owner_id)
+
+    return result, result_ids
+
+
+def replace(parent: Generator, old_gen: Union[Generator, Iterable[Generator]],
+            new_gen: Union[Generator, Iterable[Generator]],
+            ignored_ports: Union[List[PortReference],
+                                 Tuple[PortReference]] = ()):
     """
     replace the old_gen with the new generator. The interfaces of
-    @old_gen has to be the same as the @new_gen
+    @old_gen has to be the same as the @new_gen while counting the internal
+    connections
 
     :param parent: parent generator that holds the old_gen
-    :param old_gen: target generator to be replaced
-    :param new_gen: new generator to use
+    :param old_gen: target generators to be replaced
+    :param new_gen: new generators to use
+    :param ignored_ports: ports to ignore when doing replacement. it's caller's
+                          responsibility to keep track of this
     :return: None
     """
     # we first make sure that the interfaces are the same
-    assert len(old_gen.ports) == len(new_gen.ports)
-    for port_name, old_port in old_gen.ports.items():
-        assert port_name in new_gen.ports
-        new_port = new_gen.ports[port_name]
+    if not isinstance(old_gen, (list, tuple)):
+        old_gen = [old_gen]
+    if not isinstance(new_gen, (list, tuple)):
+        new_gen = [new_gen]
+    # get external ports
+    old_gen_ports, old_gen_ids = __get_external_ports(parent, old_gen,
+                                                      ignored_ports)
+    new_gen_ports, new_gen_ids = __get_external_ports(parent, new_gen,
+                                                      ignored_ports)
+
+    assert len(old_gen_ports) == len(new_gen_ports)
+    # this matching algorithm is n^2
+    # unless we know something about the port names (i.e. unique)
+    # this is the best we can do
+    for port_name, owner in old_gen_ports.items():
+        assert port_name in new_gen_ports
+        old_port = owner.ports[port_name]
+        new_port = new_gen_ports[port_name].ports[port_name]
         assert old_port.base_type() == new_port.base_type()
 
     # looping through the wires in parent that need to be replaced
     wires = set()
     for conn_from, conn_to in parent.wires:
-        if conn_from.owner() == old_gen:
+        if id(conn_from.owner()) in old_gen_ids:
             wires.add((conn_from, conn_to))
-        if conn_to.owner() == old_gen:
+        if id(conn_to.owner()) in old_gen_ids:
             wires.add((conn_from, conn_to))
 
     # remove the wires
@@ -83,15 +146,18 @@ def replace(parent: Generator, old_gen: Generator, new_gen: Generator):
 
     # adding wires back using the new generator
     for conn_from, conn_to in wires:
-        if conn_from.owner() == old_gen:
+        if id(conn_from.owner()) in old_gen_ids:
             next_port = conn_to
             current_port = conn_from.clone()
+
+            new_generator = new_gen_ports[conn_from.qualified_name()]
         else:
-            assert conn_to.owner() == old_gen
+            assert id(conn_to.owner()) in old_gen_ids
             next_port = conn_from
             current_port = conn_to.clone()
+            new_generator = new_gen_ports[conn_to.qualified_name()]
 
         # reconstructing the port based on the ops stored in the original port
         # slices
-        new_port = current_port.get_port(new_gen.ports)
+        new_port = current_port.get_port(new_generator.ports)
         parent.wire(new_port, next_port)

--- a/tests/common/test_transform.py
+++ b/tests/common/test_transform.py
@@ -5,87 +5,114 @@ import fault
 import tempfile
 
 
+class Child1(Generator):
+    CONST = 1
+
+    def __init__(self, width):
+        super().__init__()
+
+        self.add_ports(
+            port0=magma.In(magma.Bits[width]),
+            port1=magma.Out(magma.Bits[width]),
+        )
+
+        add_ = FromMagma(mantle.DefineAdd(width))
+        self.wire(self.ports["port0"], add_.ports.I0)
+        self.wire(Const(self.CONST), add_.ports.I1)
+        self.wire(self.ports["port1"], add_.ports.O)
+
+    def name(self):
+        return "Child1"
+
+
+class Child2(Generator):
+    CONST = 2
+
+    def __init__(self, width):
+        super().__init__()
+
+        self.add_ports(
+            port0=magma.In(magma.Bits[width]),
+            port1=magma.Out(magma.Bits[width]),
+        )
+
+        add_ = FromMagma(mantle.DefineMul(width))
+        self.wire(self.ports["port0"], add_.ports.I0)
+        self.wire(Const(self.CONST), add_.ports.I1)
+        self.wire(self.ports["port1"], add_.ports.O)
+
+    def name(self):
+        return "Child2"
+
+
+class Child3(Generator):
+    def __init__(self, width):
+        super().__init__()
+
+        child_2_const = 2
+
+        self.add_ports(
+            port0=magma.In(magma.Bits[width + 1]),
+            port1=magma.Out(magma.Bits[width + 1]),
+        )
+
+        add_ = FromMagma(mantle.DefineAdd(width))
+        self.wire(self.ports["port0"], add_.ports.I0)
+        self.wire(Const(child_2_const), add_.ports.I1)
+        self.wire(self.ports["port1"], add_.ports.O)
+
+    def name(self):
+        return "Child3"
+
+
+class Child4(Generator):
+    def __init__(self, width):
+        super().__init__()
+
+        self.add_ports(
+            port0=magma.In(magma.Bits[width]),
+            port2=magma.In(magma.Bits[width]),
+            port1=magma.Out(magma.Bits[width]),
+        )
+
+        add_ = FromMagma(mantle.DefineMul(width))
+        self.wire(self.ports["port0"], add_.ports.I0)
+        self.wire(self.ports["port2"], add_.ports.I1)
+        self.wire(self.ports["port1"], add_.ports.O)
+
+    def name(self):
+        return "Child4"
+
+
+class Parent(Generator):
+    def __init__(self, width):
+        super().__init__()
+        self.add_ports(
+            port0=magma.In(magma.Bits[width]),
+            port1=magma.Out(magma.Bits[width])
+        )
+
+        self.child = Child1(width)
+        self.wire(self.ports.port0, self.child.ports.port0)
+        self.wire(self.ports.port1, self.child.ports.port1)
+
+    def name(self):
+        return "Parent"
+
+
 def test_remove_simple():
     width = 16
     num_inputs = 10
-    child_1_const = 1
-    child_2_const = 2
 
-    class Child1(Generator):
-        def __init__(self):
-            super().__init__()
-
-            self.add_ports(
-                port0=magma.In(magma.Bits[width]),
-                port1=magma.Out(magma.Bits[width]),
-            )
-
-            add_ = FromMagma(mantle.DefineAdd(width))
-            self.wire(self.ports["port0"], add_.ports.I0)
-            self.wire(Const(child_1_const), add_.ports.I1)
-            self.wire(self.ports["port1"], add_.ports.O)
-
-        def name(self):
-            return "Child1"
-
-    class Child2(Generator):
-        def __init__(self):
-            super().__init__()
-
-            self.add_ports(
-                port0=magma.In(magma.Bits[width]),
-                port1=magma.Out(magma.Bits[width]),
-            )
-
-            add_ = FromMagma(mantle.DefineMul(width))
-            self.wire(self.ports["port0"], add_.ports.I0)
-            self.wire(Const(child_2_const), add_.ports.I1)
-            self.wire(self.ports["port1"], add_.ports.O)
-
-        def name(self):
-            return "Child2"
-
-    class Child3(Generator):
-        def __init__(self):
-            super().__init__()
-
-            self.add_ports(
-                port0=magma.In(magma.Bits[width + 1]),
-                port1=magma.Out(magma.Bits[width + 1]),
-            )
-
-            add_ = FromMagma(mantle.DefineAdd(width))
-            self.wire(self.ports["port0"], add_.ports.I0)
-            self.wire(Const(child_2_const), add_.ports.I1)
-            self.wire(self.ports["port1"], add_.ports.O)
-
-        def name(self):
-            return "Child3"
-
-    class Parent(Generator):
-        def __init__(self):
-            super().__init__()
-            self.add_ports(
-                port0=magma.In(magma.Bits[width]),
-                port1=magma.Out(magma.Bits[width])
-            )
-
-            self.child = Child1()
-            self.wire(self.ports.port0, self.child.ports.port0)
-            self.wire(self.ports.port1, self.child.ports.port1)
-
-        def name(self):
-            return "Parent"
-
-    parent = Parent()
-    new_child = Child3()
+    parent = Parent(width)
+    new_child = Child3(width)
     try:
         # try to replace one with different interface
         replace(parent, parent.child, new_child)
         assert False
     except AssertionError:
         pass
-    new_child = Child2()
+    new_child = Child2(width)
     replace(parent, parent.child, new_child)
 
     circuit = parent.circuit()
@@ -94,7 +121,64 @@ def test_remove_simple():
     for i in range(num_inputs):
         tester.poke(circuit.port0, inputs[i])
         tester.eval()
-        tester.expect(circuit.port1, inputs[i] * child_2_const)
+        tester.expect(circuit.port1, inputs[i] * Child2.CONST)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tester.compile_and_run(directory=tempdir,
+                               magma_output="coreir-verilog",
+                               flags=["-Wno-fatal"])
+
+
+def test_remove_complex():
+    width = 16
+    num_inputs = 10
+
+    parent = Parent(width)
+
+    # we want to group child1 and child2 together to replace parent.child
+    new_child1 = Child1(width)
+    new_child2 = Child2(width)
+    parent.wire(new_child1.ports.port1, new_child2.ports.port0)
+    replace(parent, parent.child, [new_child1, new_child2])
+
+    circuit = parent.circuit()
+    tester = fault.Tester(circuit)
+    inputs = [fault.random.random_bv(width) for _ in range(num_inputs)]
+    for i in range(num_inputs):
+        tester.poke(circuit.port0, inputs[i])
+        tester.eval()
+        tester.expect(circuit.port1, (inputs[i] + Child1.CONST) * Child2.CONST)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tester.compile_and_run(directory=tempdir,
+                               magma_output="coreir-verilog",
+                               flags=["-Wno-fatal"])
+
+
+def test_remove_complex_ignore():
+    width = 16
+    num_inputs = 10
+    # 42 is the answer to everything
+    const = 42
+
+    parent = Parent(width)
+
+    # we want to group child1 and child2 together to replace parent.child
+    new_child1 = Child1(width)
+    new_child4 = Child4(width)
+    parent.wire(new_child1.ports.port1, new_child4.ports.port0)
+    replace(parent, parent.child, [new_child1, new_child4],
+            ignored_ports=[new_child4.ports.port2])
+    # we have to wire this port by ourselves
+    parent.wire(new_child4.ports.port2, Const(const))
+
+    circuit = parent.circuit()
+    tester = fault.Tester(circuit)
+    inputs = [fault.random.random_bv(width) for _ in range(num_inputs)]
+    for i in range(num_inputs):
+        tester.poke(circuit.port0, inputs[i])
+        tester.eval()
+        tester.expect(circuit.port1, (inputs[i] + Child1.CONST) * const)
 
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(directory=tempdir,


### PR DESCRIPTION
Based on the conversation with Ankita, we need to use one AND gate and one AOI Mux to replace the original MUX. One of the AND signal will come from somewhere else (config register). As a result, the simple `replace` pass just introduced is not sufficient enough. The new passe allows:
1. Replace a group/single generator with a group/single generator. The pass will calculate existing internal wiring inside the group, within `parent`, to filter out which wires to remove and validate. By default this is very conservative.
2. Allow caller to supply ports to the whitelist. This is desirable since some opening ports will be connected later in the generation stage (useful for power domain)

Testing:
1. Original one-to-one replacement test
2. One-to-two replacement test
3. One-to-two replacement with one port whitelisted.