### PR TITLE
Genesis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
     - pip install python-coveralls
     - pip install pytest-cov pytest-codestyle
     - pip install -e .
+    - pip install -e git+git://github.com/phanrahan/magma.git#egg=magma-lang
 
     # BEGIN GENESIS2 INSTALL
     - git clone https://github.com/StanfordVLSI/Genesis2.git

--- a/gemstone/common/genesis_wrapper.py
+++ b/gemstone/common/genesis_wrapper.py
@@ -13,7 +13,7 @@ default_type_map = {"clk": m.In(m.Clock),
 
 class GenesisWrapper:
     def __init__(self, interface, top_name, default_infiles,
-                 system_verilog=False, type_map={}):
+                 system_verilog=False, type_map={}, external_modules={}):
         """
         `interface`: the generator params and default values
         `top_name`: the name of the top module
@@ -31,6 +31,7 @@ class GenesisWrapper:
         self.__default_infiles = default_infiles
         self.__type_map = type_map
         self.__cache = {}
+        self.__external_modules = external_modules
 
     def generator(self, param_mapping: Dict[str, str] = None,
                   mode: str = "define"):
@@ -76,7 +77,8 @@ class GenesisWrapper:
                         with open(outfile, "rb") as fd:
                             shutil.copyfileobj(fd, combined)
                 magma_defns = func(combined_filename, type_map=self.__type_map,
-                                   target_modules=[self.__top_name])
+                                   target_modules=[self.__top_name],
+                                   external_modules=self.__external_modules)
                 assert len(magma_defns) == 1
                 defn = magma_defns[0]
                 self.__cache[cache_key] = defn

--- a/gemstone/common/genesis_wrapper.py
+++ b/gemstone/common/genesis_wrapper.py
@@ -30,6 +30,7 @@ class GenesisWrapper:
         self.__top_name = top_name
         self.__default_infiles = default_infiles
         self.__type_map = type_map
+        self.__cache = {}
 
     def generator(self, param_mapping: Dict[str, str] = None,
                   mode: str = "define"):
@@ -52,6 +53,11 @@ class GenesisWrapper:
                 else:
                     parameters[param] = kwargs.get(param, default)
 
+            cache_key = tuple(parameters.values())
+            cache_key = (mode, *cache_key)
+            if cache_key in self.__cache:
+                return self.__cache[cache_key]
+
             # Allow user to override default input_files
             infiles = kwargs.get("infiles", self.__default_infiles)
 
@@ -72,7 +78,9 @@ class GenesisWrapper:
                 magma_defns = func(combined_filename, type_map=self.__type_map,
                                    target_modules=[self.__top_name])
                 assert len(magma_defns) == 1
-                return magma_defns[0]
+                defn = magma_defns[0]
+                self.__cache[cache_key] = defn
+                return defn
 
         return define_wrapper
 

--- a/gemstone/common/genesis_wrapper.py
+++ b/gemstone/common/genesis_wrapper.py
@@ -70,15 +70,18 @@ class GenesisWrapper:
             else:
                 raise NotImplementedError(f"Unsupported mode '{mode}'")
 
+            func_kwargs = dict(type_map=self.__type_map,
+                               target_modules=[self.__top_name])
+            if func is m.DefineFromVerilogFile:
+                func_kwargs.update(dict(external_modules=self.__external_modules))
+
             with tempfile.TemporaryDirectory() as tempdir:
                 combined_filename = tempdir + "/combined.v"
                 with open(combined_filename, "wb") as combined:
                     for outfile in outfiles:
                         with open(outfile, "rb") as fd:
                             shutil.copyfileobj(fd, combined)
-                magma_defns = func(combined_filename, type_map=self.__type_map,
-                                   target_modules=[self.__top_name],
-                                   external_modules=self.__external_modules)
+                magma_defns = func(combined_filename, **func_kwargs)
                 assert len(magma_defns) == 1
                 defn = magma_defns[0]
                 self.__cache[cache_key] = defn

--- a/gemstone/common/run_genesis.py
+++ b/gemstone/common/run_genesis.py
@@ -5,8 +5,7 @@ from typing import Union, List, Any
 def run_genesis(top: str,
                 in_file_or_files: Union[str, List[str]],
                 parameters: dict,
-                genesis_cmd: str = "Genesis2.pl",
-                system_verilog: bool = False):
+                genesis_cmd: str = "Genesis2.pl"):
     """
     Run genesis using the .vp file(s) @in_file_or_files using @parameters with
     the top as @top. Returns the path of the output verilog file if
@@ -19,9 +18,11 @@ def run_genesis(top: str,
         files = " ".join(files)
 
     cmd = (f"{genesis_cmd} -parse -generate -top {top} "
-           f"-input {files} " + " ".join(param_strs))
+           f"-input {files} -product product.txt " + " ".join(param_strs))
     print(f"Running genesis cmd '{cmd}'")
     res = os.system(cmd)
     if not res == 0:
         raise RuntimeError(f"Genesis failed! cmd = {cmd}")
-    return f"genesis_verif/{top}.{'sv' if system_verilog else 'v'}"
+    with open("product.txt", "r") as f:
+        lines = f.readlines()
+        return [line.strip() for line in lines]

--- a/tests/common/test_genesis_wrapper.py
+++ b/tests/common/test_genesis_wrapper.py
@@ -45,6 +45,21 @@ def test_generator(mode):
         assert type(expected_ports[name]) == type(type_)
 
 
+def test_wrapper_cache_hit():
+    generator = WRAPPER.generator()
+    module = generator(**PARAMS)
+    module_copy = generator(**PARAMS)
+    assert module is module_copy
+
+
+def test_wrapper_cache_miss():
+    generator = WRAPPER.generator()
+    module = generator(width=1)
+    module_copy = generator(width=2)
+    assert module is not module_copy
+    assert repr(module) != repr(module_copy)
+
+
 def test_parser_basic():
     parser = WRAPPER.parser()
     w = random.randint(0, 100)

--- a/tests/common/test_genesis_wrapper.py
+++ b/tests/common/test_genesis_wrapper.py
@@ -77,8 +77,9 @@ def test_main(capsys):
     w = random.randint(0, 100)
     WRAPPER.main(argv=["--width", str(w)])
     out, _ = capsys.readouterr()
-    expected_out = f"""\
-Running genesis cmd 'Genesis2.pl -parse -generate -top test_run_genesis -input {''.join(INFILES)} -parameter test_run_genesis.width='{w}''
-test_run_genesis(clk: In(Bit), reset: In(Bit), in0: In(Bits[{w}]), in1: In(Bits[{w}]), sel: In(Bit), out: Out(Bits[{w}]))
-"""  # nopep8
+    out = out.rstrip().split("\n")[1:]
+    expected_out = [
+        f"test_run_genesis(clk: In(Bit), reset: In(Bit), in0: In(Bits[{w}]), in1: In(Bits[{w}]), sel: In(Bit), out: Out(Bits[{w}]))",  # nopep8
+    ]
+    # nopep8
     assert out == expected_out

--- a/tests/common/test_run_genesis.py
+++ b/tests/common/test_run_genesis.py
@@ -9,7 +9,6 @@ PARAMS = {
 
 
 def get_lines(filename):
-    lines = []
     with open(filename) as f:
         return f.readlines()
 
@@ -20,7 +19,9 @@ def test_run_genesis_basic():
     that it raises an exception on failure.
     """
     GOLDEN = "tests/common/gold/test_run_genesis.v"
-    verilog_file = run_genesis(TOP, INFILES, PARAMS)
+    verilog_files = run_genesis(TOP, INFILES, PARAMS)
+    assert len(verilog_files) == 1
+    verilog_file = verilog_files[0]
     golden_lines = get_lines(GOLDEN)
     genesis_lines = get_lines(verilog_file)
     assert golden_lines[40:] == genesis_lines[40:]
@@ -32,7 +33,7 @@ def test_run_genesis_bad_params():
     bad_params = PARAMS.copy()
     bad_params.update({"some_non_existent_param": 0})
     try:
-        verilog_file = run_genesis(TOP, INFILES, bad_params)
+        run_genesis(TOP, INFILES, bad_params)
         assert False
     except RuntimeError as e:
         msg = e.__str__()


### PR DESCRIPTION
-- Capture entire genesis output
-- Cache genesis generators

Removes need to do any caching logic in downstream tools (gemstone does it for you). Also don't need to do any hacky copying of files etc. It is all captured in `DeclareFromVerilogFile` used in (`run_genesis`) now.