### PR TITLE
Add hierarchy manipulation passes from garnet repo

### DIFF
--- a/gemstone/common/group.py
+++ b/gemstone/common/group.py
@@ -1,0 +1,76 @@
+import magma
+from ..generator.generator import Generator
+
+
+class _GroupWrapper(Generator):
+    def __init__(self, name, instances, prefixes=None):
+        super().__init__()
+
+        self.__name = name
+        self.instances = instances
+        self.port_map = {}
+        if prefixes is None:
+            prefixes = [f"Inst{i}_" for i in range(len(self.instances))]
+        for i, inst in enumerate(self.instances):
+            prefix = prefixes[i]
+            for key, port in inst.ports.items():
+                new_key = f"{prefix}{key}"
+                self.add_port(new_key, port.type())
+                self.wire(port, self.ports[new_key])
+                self.port_map[port] = self.ports[new_key]
+
+    def name(self):
+        return self.__name
+
+
+class _GeneratorBuilder(Generator):
+    def __init__(self, name=None):
+        super().__init__()
+
+        self.__name = name
+
+    def name(self):
+        return self.__name
+
+    def set_name(self, name):
+        self.__name = name
+
+
+def _get_external(wire, insts):
+    port0, port1 = wire
+    if port0.owner() in insts and port1.owner() not in insts:
+        return (port1, port0)
+    if port1.owner() in insts and port0.owner() not in insts:
+        return (port0, port1)
+    return None
+
+
+def group(top: Generator, group_name, *insts):
+    children = top.children().copy()
+    assert all(inst in children for inst in insts)
+    wrapper = _GeneratorBuilder(name=group_name)
+    top_wires = top.wires.copy()
+    removed_wires = []
+    removed_internal_wires = []
+    for top_wire in top_wires:
+        sorted_ = _get_external(top_wire, insts)
+        if sorted_ is None:
+            port0, port1 = top_wire
+            if port0.owner() in insts and port1.owner() in insts:
+                top.remove_wire(port0, port1)
+                removed_internal_wires.append((port0, port1))
+            continue
+        external, internal = sorted_
+        top.remove_wire(external, internal)
+        removed_wires.append((external, internal))
+    counter = 0
+    removed_wires_sorted = sorted(removed_wires, key=lambda x: hash(x[1]))
+    for external, internal in removed_wires_sorted:
+        new_port_name = f"port{counter}"
+        counter += 1
+        wrapper.add_port(new_port_name, internal.type())
+        wrapper.wire(internal, wrapper.ports[new_port_name])
+        top.wire(wrapper.ports[new_port_name], external)
+    for port0, port1 in removed_internal_wires:
+        wrapper.wire(port0, port1)
+    return wrapper

--- a/gemstone/common/ungroup.py
+++ b/gemstone/common/ungroup.py
@@ -1,0 +1,155 @@
+import magma
+from ..generator.const import Const
+from ..generator.generator import Generator
+from hwtypes import BitVector
+from collections import defaultdict
+from ..generator.port_reference import PortReferenceBase
+
+class PassThrough(Generator):
+    def __init__(self, port_type, name):
+        super().__init__()
+        self.__name = name
+        T = port_type
+        # To guarantee that I is an input type
+        if T.isoutput():
+            T = T.flip()
+
+        self.add_ports(
+            I=T,
+            O=T.flip(),
+        )
+        self.wire(self.ports.I, self.ports.O)
+
+    def name(self):
+        return self.__name
+    
+def get_external_connections(port: PortReferenceBase):
+    external = []
+    for conn in port._connections:
+        if port.owner() != conn.owner():
+            external.append(conn)
+    return external
+    
+
+def ungroup(top: Generator, *insts):
+    # If no insts are provided, ungroup all children
+    if len(insts) == 0:
+        insts = top.children()
+    for inst in insts:
+        assert(inst in top.children())
+        # Dictionary of wires to remove keyed by inst port name
+        connections_to_replace = defaultdict(lambda: defaultdict(list))
+        pass_through_connections = set()
+        for wire in top.wires:
+            # Find any top level wire that goes to the inst we want to ungroup
+            for (ind, port) in enumerate(wire):
+                if port.owner() == inst:
+                    top_port = wire[ind - 1]
+                    port_key = hash(port)
+                    # check if either of the endpoints are split
+                    if (len(port._ops) > 0) or (len(top_port._ops) > 0):
+                        connections_to_replace[port_key]['split'] = True
+                    connections_to_replace[port_key]['ext_intermediate'].append(port)
+                    connections_to_replace[port_key]['external'].append(top_port)
+        
+        # Find any inst level wire connected to one of the insts ports
+        for wire in inst.wires:
+            for (ind, port) in enumerate(wire):
+                if port.owner() == inst:
+                    internal_port = wire[ind - 1]
+                    port_key = hash(port)
+                    # check if either of the endpoints are split
+                    if (len(port._ops) > 0) or (len(internal_port._ops) > 0):
+                        connections_to_replace[port_key]['split'] = True
+                    # Handle pass through case here
+                    if internal_port.owner() == inst:
+                        pass_through_connections.add(wire)
+                    else:
+                        connections_to_replace[port_key]['int_intermediate'].append(port)
+                        connections_to_replace[port_key]['internal'].append(internal_port)
+
+        # Handle the pass through connections
+        pass_through_insts = []
+        for (p1, p2) in pass_through_connections:
+            if p1.type().isinput():
+                in_port = p1
+                out_port = p2
+            else:
+                in_port = p2
+                out_port = p1
+            # For all pass through connections, insert a PassThrough module (to be removed later)
+            pass_through_inst = PassThrough(in_port.type(), "passthrough")
+            inst.remove_wire(in_port, out_port)
+            inst.wire(in_port, pass_through_inst.ports.I)
+            inst.wire(out_port, pass_through_inst.ports.O)
+            # Keep track of all the pass_through insts we insert here so we can clean them up later
+            pass_through_insts.append(pass_through_inst)
+            for port in (in_port, out_port):
+                key = hash(port)
+                connection = connections_to_replace[key]
+                connection['int_intermediate'].append(port)
+                if port == in_port:
+                    connection['internal'].append(pass_through_inst.ports.I)
+                else:
+                    connection['internal'].append(pass_through_inst.ports.O)
+        
+        # Now replace all (external <-> intermediate) and (intermediate <-> internal) connections
+        # with (external <-> internal) connections
+        # First break the connections
+        for connection in connections_to_replace.values():
+            # Break external connections
+            for external, intermediate in zip(connection['external'], connection['ext_intermediate']):
+                top.remove_wire(intermediate, external)
+            # Break internal connections
+            for internal, intermediate in zip(connection['internal'], connection['int_intermediate']):
+                inst.remove_wire(intermediate, internal)
+
+        # Now reconnect everything 
+        for connection in connections_to_replace.values():
+            assert(len(connection['external']) == len(connection['ext_intermediate']))
+            assert(len(connection['internal']) == len(connection['int_intermediate']))
+            # Split connection
+            if connection['split'] == True:
+                print(f"Split connection detected for intermediate port {connection['int_intermediate'][0].qualified_name()}")
+                intermediate = connection['ext_intermediate'][0]
+                _port_combiner = PassThrough(intermediate.base_type(), f"splitport{intermediate.qualified_name()}")
+                if intermediate.type().isinput():
+                    external_combiner = _port_combiner.ports.I 
+                    internal_combiner = _port_combiner.ports.O
+                else:
+                    external_combiner = _port_combiner.ports.O 
+                    internal_combiner = _port_combiner.ports.I
+                # Use ops of the external and internal intermediate ports
+                # to handle split connections properly
+                for external, ext_intermediate in zip(connection['external'], connection['ext_intermediate']):
+                    intermediate = external_combiner
+                    #intermediate._ops = []
+                    for op in ext_intermediate._ops:
+                        intermediate = op(intermediate)
+                    top.wire(external, intermediate)
+                for internal, int_intermediate in zip(connection['internal'], connection['int_intermediate']):
+                    intermediate = internal_combiner
+                    #intermediate._ops = []
+                    for op in int_intermediate._ops:
+                        intermediate = op(intermediate)
+                    top.wire(internal, intermediate)
+            # No split connection
+            else:
+                for external in connection['external']:
+                    for internal in connection['internal']:
+                        top.wire(external, internal)
+
+        # Finally, clean up the PassThroughs
+        for pass_through_inst in pass_through_insts:
+            external_inputs = get_external_connections(pass_through_inst.ports.I)
+            external_outputs = get_external_connections(pass_through_inst.ports.O)
+            assert(len(external_inputs) == 1)
+            assert(len(external_inputs) == len(external_outputs))
+            # Bypass pass-through connection
+            top.remove_wire(external_inputs[0], pass_through_inst.ports.I)
+            top.remove_wire(external_outputs[0], pass_through_inst.ports.O)
+            top.wire(external_inputs[0], external_outputs[0])
+        
+        # At this point, all remaining connections in inst will be purely internal.
+        # Move these internal connections into the top level
+        top.wires.extend(inst.wires)


### PR DESCRIPTION
Taking the group and ungroup passes we developed in the Garnet repo and moving them here since they're not specific to Garnet.