### PR TITLE
Pinning pass

### DIFF
--- a/gemstone/common/assign_abutted_pins.py
+++ b/gemstone/common/assign_abutted_pins.py
@@ -31,7 +31,7 @@ def __reorder_pins(pin_dict, side_1, side_2):
     return pin_dict
             
 
-def assign_abutted_pins(primary: Generator, **kwargs):
+def assign_abutted_pins(primary: Generator, output_to_file=True, **kwargs):
     # Make sure kwargs are valid
     for side in kwargs.keys():
         if side not in ['left', 'right', 'top', 'bottom']:
@@ -56,12 +56,14 @@ def assign_abutted_pins(primary: Generator, **kwargs):
     pin_objs = __reorder_pins(pin_objs, 'left', 'right') 
     pin_objs = __reorder_pins(pin_objs, 'top', 'bottom') 
 
-    # Spit out the pin names for each side 
-    for side, pin_list in pin_objs.items():
-        filename = f"pinning_results/{side}.txt"
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
-        with open(filename, "w") as f:
-            for pin in pin_list:
-                f.write(f"{pin.qualified_name()}\n")
-        f.close()
+    # Spit out the pin names for each side
+    if output_to_file == True: 
+        for side, pin_list in pin_objs.items():
+            filename = f"pinning_results/{side}.txt"
+            os.makedirs(os.path.dirname(filename), exist_ok=True)
+            with open(filename, "w") as f:
+                for pin in pin_list:
+                    f.write(f"{pin.qualified_name()}\n")
+            f.close()
 
+    return pin_objs

--- a/gemstone/common/assign_abutted_pins.py
+++ b/gemstone/common/assign_abutted_pins.py
@@ -1,6 +1,6 @@
 import magma
 import warnings
-from gemstone.generator.generator import Generator
+from ..generator.generator import Generator
 import os
 
 # Use kwargs left, right, top, bottom to match other blocks

--- a/gemstone/common/assign_abutted_pins.py
+++ b/gemstone/common/assign_abutted_pins.py
@@ -1,0 +1,67 @@
+import magma
+import warnings
+from gemstone.generator.generator import Generator
+import os
+
+# Use kwargs left, right, top, bottom to match other blocks
+# with correct side of primary block
+# Allowed kwargs : left, right, top, bottom
+
+def __get_external_connections(pin):
+    ext_conns = []
+    for conn in pin._connections:
+        if (conn.owner() not in (pin.owner().children())) and (conn.owner() != pin.owner()):
+            ext_conns.append(conn)
+    return ext_conns
+
+def __reorder_pins(pin_dict, side_1, side_2):
+    s1_pins = pin_dict[side_1]
+    s2_pins = pin_dict[side_2]
+    s2_pin_names = list(map(lambda pin_obj: pin_obj.qualified_name(), s2_pins))
+    for i, pin in enumerate(s1_pins):
+        ext_conns = __get_external_connections(pin)
+        if ext_conns[0].qualified_name() in s2_pin_names:
+            curr_idx = s2_pin_names.index(ext_conns[0].qualified_name())
+            s2_pin_names.insert(i, s2_pin_names.pop(curr_idx))
+            s2_pins.insert(i, s2_pins.pop(curr_idx))
+        else:
+            warnings.warn(f"{side_1} side pin {pin.qualified_name()} not found \
+                            in {side_2} side connections. Abutment may not \
+                            be possible")
+    return pin_dict
+            
+
+def assign_abutted_pins(primary: Generator, **kwargs):
+    # Make sure kwargs are valid
+    for side in kwargs.keys():
+        if side not in ['left', 'right', 'top', 'bottom']:
+            raise Exception('kwarg key must be left, right, top, or bottom')
+
+    pin_objs = {'left': [], 'right': [], 'top': [], 'bottom': [], 'other': []}   
+
+    for port in primary.ports.values():
+        # Remove any internal connections
+        conns = __get_external_connections(port)
+        if len(conns) == 1:
+            for side, inst in kwargs.items():
+                if conns[0].owner() == inst:
+                    pin_objs[side].append(port)
+                    break
+        elif len(conns) == 0:
+            pin_objs['other'].append(port)
+        else:
+            raise Exception('cannot abut port with fanout connection')
+
+    # Make L/R, T/B ordering consistent
+    pin_objs = __reorder_pins(pin_objs, 'left', 'right') 
+    pin_objs = __reorder_pins(pin_objs, 'top', 'bottom') 
+
+    # Spit out the pin names for each side 
+    for side, pin_list in pin_objs.items():
+        filename = f"pinning_results/{side}.txt"
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        with open(filename, "w") as f:
+            for pin in pin_list:
+                f.write(f"{pin.qualified_name()}\n")
+        f.close()
+

--- a/tests/common/test_assign_abutted_pins.py
+++ b/tests/common/test_assign_abutted_pins.py
@@ -1,0 +1,79 @@
+import magma
+import mantle
+from gemstone.generator.generator import Generator
+from gemstone.generator.from_magma import FromMagma
+from gemstone.common.mux_wrapper import MuxWrapper
+from gemstone.common.assign_abutted_pins import assign_abutted_pins
+
+
+class SomeFunctionalCell(Generator):
+    def __init__(self, width):
+        super().__init__()
+
+        self.width = width
+        T = magma.Bits[self.width]
+
+        self.add_ports(
+            I1=magma.In(T),
+            I2=magma.In(T),
+            I3=magma.In(T),
+            O3=magma.Out(T),
+            O1=magma.Out(T),
+            O2=magma.Out(T),
+        )
+        assert(self.width > 1)
+        self.wire(self.ports.I1, self.ports.O1)
+        self.wire(self.ports.I2, self.ports.O2)
+        self.wire(self.ports.I3, self.ports.O3)
+
+    def name(self):
+        return f"Cell{self.width}"
+
+
+class ChainOfCells(Generator):
+    def __init__(self):
+        super().__init__()
+
+        self.width = 2
+        self.length = 8
+
+        T = magma.Bits[self.width]
+
+        self.add_ports(
+            I1=magma.In(T),
+            I2=magma.In(T),
+            I3=magma.In(T),
+            O1=magma.Out(T),
+            O2=magma.Out(T),
+            O3=magma.Out(T),
+        )
+
+        self.cells = [SomeFunctionalCell(self.width) for _ in range(self.length)]
+
+        self.wire(self.ports.I1, self.cells[0].ports.I1)
+        self.wire(self.ports.I2, self.cells[0].ports.I2)
+        self.wire(self.ports.I3, self.cells[0].ports.I3)
+        for i, cell in enumerate(self.cells):
+            if i == (len(self.cells) - 1):
+                self.wire(cell.ports.O1, self.ports.O1)
+                self.wire(cell.ports.O2, self.ports.O2)
+                self.wire(cell.ports.O3, self.ports.O3)
+                continue
+            self.wire(cell.ports.O1, self.cells[i + 1].ports.I1)
+            self.wire(cell.ports.O2, self.cells[i + 1].ports.I2)
+            self.wire(cell.ports.O3, self.cells[i + 1].ports.I3)
+
+    def name(self):
+        return "ChainOfCells"
+
+
+def test_assign_abutted_pins():
+    gen = ChainOfCells()
+    cell = gen.cells[1]
+    pin_objs = assign_abutted_pins(cell, False, left=gen.cells[0], right=gen.cells[2])
+    ports = cell.ports
+    expected_pin_objs = {'left': [ports.I1, ports.I2, ports.I3],
+                         'right': [ports.O1, ports.O2, ports.O3],
+                         'top': [], 'bottom': [], 'other': []}
+    assert expected_pin_objs == pin_objs
+    

--- a/tests/common/test_assign_abutted_pins.py
+++ b/tests/common/test_assign_abutted_pins.py
@@ -1,8 +1,5 @@
 import magma
-import mantle
 from gemstone.generator.generator import Generator
-from gemstone.generator.from_magma import FromMagma
-from gemstone.common.mux_wrapper import MuxWrapper
 from gemstone.common.assign_abutted_pins import assign_abutted_pins
 
 


### PR DESCRIPTION
This pass accepts a primary instance, as well as its adjacent instances (with keywords indicating which side they live on) as arguments, and returns a pin arrangement for the primary instance which would allow it to be abutted with the adjacent instances.

Typically, the adjacent instances will be of the same module as the primary instance, or at least have identical interfaces.