### PR TITLE
fix performance issue

### DIFF
--- a/gemstone/generator/generator.py
+++ b/gemstone/generator/generator.py
@@ -132,7 +132,7 @@ class Generator(ABC):
 
     def circuit(self):
         hash_ = self.__hash
-        hash_ ^= hash(self.name())
+        hash_ ^= hash(self.name()) << 16
         if hash_ in _generator_cache:
             return _generator_cache[hash_]
 
@@ -159,7 +159,7 @@ class Generator(ABC):
                 wire1 = port1.get_port(inst1)
                 magma.wire(wire0, wire1)
 
-        _generator_cache[self.__hash] = _Circ
+        _generator_cache[hash_] = _Circ
 
         return _Circ
 


### PR DESCRIPTION
This should temporarily fix the caching issue. From the perf report I think the majority of time is spent on magma type comparisons. I will take a look after the tapeout.

Edit:
On kiwi 32x16 takes about 5.5 mins, as compared to 30 mins before.