### PR TITLE
Condensed register space

### DIFF
--- a/gemstone/common/core.py
+++ b/gemstone/common/core.py
@@ -58,6 +58,10 @@ class ConfigurableCore(Core, Configurable):
         Core.__init__(self)
         Configurable.__init__(self, config_addr_width, config_data_width)
 
+        # set to true will allow it skip reg compression on this feature
+        # during the bitstream generation stage
+        self.skip_compression = False
+
     @abstractmethod
     def get_config_bitstream(self, instr):
         pass
@@ -75,6 +79,10 @@ class CoreFeature(Generator):
 
         self.__index = index
         self.__parent = parent_core
+
+        # set to true will allow it skip reg compression on this feature
+        # during the bitstream generation stage
+        self.skip_compression = False
 
     def name(self):
         return f"{self.__parent.name()}_FEATURE_{self.__index}"

--- a/gemstone/common/dummy_core_magma.py
+++ b/gemstone/common/dummy_core_magma.py
@@ -26,26 +26,7 @@ class DummyCore(ConfigurableCore):
             dummy_2=32
         )
 
-        # Create mux allow for reading of config regs
-        num_mux_inputs = len(self.registers.values())
-        self.read_data_mux = MuxWithDefaultWrapper(num_mux_inputs, 32, 8, 0)
-        # Connect config_addr to mux select
-        self.wire(self.read_data_mux.ports.S, self.ports.config.config_addr)
-        # Connect config_read to mux enable
-        self.wire(self.read_data_mux.ports.EN[0], self.ports.config.read[0])
-        self.wire(self.read_data_mux.ports.O, self.ports.read_config_data)
-        for i, reg in enumerate(self.registers.values()):
-            reg.set_addr(i)
-            reg.set_addr_width(8)
-            reg.set_data_width(32)
-            # wire output to read_data_mux inputs
-            self.wire(reg.ports.O, self.read_data_mux.ports.I[i])
-            # Wire config addr and data to each register
-            self.wire(self.ports.config.config_addr, reg.ports.config_addr)
-            self.wire(self.ports.config.config_data, reg.ports.config_data)
-            # Wire config write to each reg's write port
-            self.wire(self.ports.config.write[0], reg.ports.config_en)
-            self.wire(self.ports.reset, reg.ports.reset)
+        self._setup_config()
 
     def get_config_bitstream(self, instr):
         raise NotImplementedError()

--- a/gemstone/common/slice_wrapper.py
+++ b/gemstone/common/slice_wrapper.py
@@ -1,0 +1,41 @@
+import magma
+from ..generator.generator import Generator
+
+
+@magma.cache_definition
+def _generate_slice_wrapper(base_width, lo, hi, name_):
+    class _SliceWrapper(magma.Circuit):
+        name = name_
+        io = magma.IO(
+            I=magma.In(magma.Bits[base_width]),
+            O=magma.Out(magma.Bits[hi - lo]),
+        )
+        magma.wire(io.I[lo:hi], io.O)
+    return _SliceWrapper
+
+
+class SliceWrapper(Generator):
+    def __init__(self, base_width, lo, hi, name=None):
+        super().__init__()
+
+        self.base_width = base_width
+        self.lo = lo
+        self.hi = hi
+        self.width = hi - lo
+
+        self.__name = name
+
+        self.add_ports(
+            I=magma.In(magma.Bits[self.base_width]),
+            O=magma.Out(magma.Bits[self.hi - lo]),
+        )
+
+    def circuit(self):
+        return _generate_slice_wrapper(self.base_width, self.lo, self.hi,
+                                       self.name())
+
+    def name(self):
+        if self.__name is None:
+            return f"SliceWrapper_{self.base_width}_{self.lo}_{self.hi}"
+        else:
+            return self.__name

--- a/gemstone/common/util.py
+++ b/gemstone/common/util.py
@@ -40,3 +40,18 @@ def check_files_equal(file1_name, file2_name):
                 for line in diff:
                     sys.stderr.write(line)
     return result
+
+
+def compress_config_data(config_data):
+    # config is reg_addr, value format
+    reg_map = {}
+    for addr, value in config_data:
+        if addr not in reg_map:
+            reg_map[addr] = 0
+        # we assume it's already shifted, by get_config_data method etc
+        reg_map[addr] = reg_map[addr] | value
+    result = []
+    for addr, value in reg_map.items():
+        if value != 0:
+            result.append((addr, value))
+    return result

--- a/gemstone/common/util.py
+++ b/gemstone/common/util.py
@@ -42,10 +42,17 @@ def check_files_equal(file1_name, file2_name):
     return result
 
 
-def compress_config_data(config_data):
+def compress_config_data(config_data, skip_compression=None):
     # config is reg_addr, value format
     reg_map = {}
+    skipped_condig_data = []
+    if skip_compression is None:
+        skip_compression = set()
+
     for addr, value in config_data:
+        if addr in skip_compression:
+            skipped_condig_data.append((addr, value))
+            continue
         if addr not in reg_map:
             reg_map[addr] = 0
         # we assume it's already shifted, by get_config_data method etc
@@ -54,4 +61,5 @@ def compress_config_data(config_data):
     for addr, value in reg_map.items():
         if value != 0:
             result.append((addr, value))
+    result = result + skipped_condig_data
     return result

--- a/tests/common/test_slice_wrapper.py
+++ b/tests/common/test_slice_wrapper.py
@@ -1,0 +1,25 @@
+import pytest
+import random
+import tempfile
+import fault
+from gemstone.common.slice_wrapper import SliceWrapper
+
+
+@pytest.mark.parametrize("lo,hi", [(5, 10), (10, 11)])
+def test_slice_wrapper(lo, hi):
+    width = 32
+    slice_wrapper = SliceWrapper(width, lo, hi)
+    slice_wrapper_circuit = slice_wrapper.circuit()
+
+    tester = fault.Tester(slice_wrapper_circuit)
+    for _ in range(10):
+        value = random.randint(0, (1 << width) - 1)
+        expected_value = (value >> lo) & ((1 << hi) - 1)
+        tester.poke(slice_wrapper_circuit.I, value)
+        tester.eval()
+        tester.expect(slice_wrapper_circuit.O, expected_value)
+    with tempfile.TemporaryDirectory() as tempdir:
+        tester.compile_and_run(target="verilator",
+                               directory=tempdir,
+                               magma_output="coreir-verilog",
+                               flags=["-Wno-fatal"])

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -1,6 +1,6 @@
 import tempfile
 import pathlib
-from gemstone.common.util import ip_available, deprecated
+from gemstone.common.util import ip_available, deprecated, compress_config_data
 
 
 def test_ip_available():
@@ -24,3 +24,24 @@ def test_deprecated():
     except RuntimeError as e:
         expected_msg = "Function foo is deprecated: foo is deprecated"
         assert e.__str__() == expected_msg
+
+
+def test_comparess_config_data():
+    # test out compressing bitstream
+    config_data = [(0, 1), (0, 2)]
+    config_data = compress_config_data(config_data)
+    assert len(config_data) == 1
+    assert config_data[0][0] == 0
+    assert config_data[0][1] == 1 | 2
+
+    # test out duplicate without zeroing out, which is required to get rom
+    # working under current lake design
+    config_data = [(0, 0), (0, 1), (0, 2),
+                   (1, 0), (1, 0), (1, 0)]
+    config_data = compress_config_data(config_data, skip_compression=[1])
+    assert len(config_data) == 1 + 3
+    assert config_data[0][0] == 0
+    assert config_data[0][1] == 1 | 2
+    for i in range(1, 4):
+        config_data[i][0] == 1
+        config_data[i][1] == 0

--- a/tests/generator/gold/core_instance_name.v
+++ b/tests/generator/gold/core_instance_name.v
@@ -1,11 +1,15 @@
-module coreir_ult #(
-    parameter width = 1
-) (
-    input [width-1:0] in0,
-    input [width-1:0] in1,
-    output out
+module dummy_2 (
+    input [31:0] I,
+    output [31:0] O
 );
-  assign out = in0 < in1;
+assign O = I;
+endmodule
+
+module dummy_1 (
+    input [31:0] I,
+    output [31:0] O
+);
+assign O = I;
 endmodule
 
 module coreir_reg_arst #(
@@ -70,8 +74,7 @@ module corebit_and (
 endmodule
 
 module commonlib_muxn__N2__width32 (
-    input [31:0] in_data_0,
-    input [31:0] in_data_1,
+    input [31:0] in_data [1:0],
     input [0:0] in_sel,
     output [31:0] out
 );
@@ -79,8 +82,8 @@ wire [31:0] _join_out;
 coreir_mux #(
     .width(32)
 ) _join (
-    .in0(in_data_0),
-    .in1(in_data_1),
+    .in0(in_data[0]),
+    .in1(in_data[1]),
     .sel(in_sel[0]),
     .out(_join_out)
 );
@@ -94,9 +97,11 @@ module Mux2xOutBits32 (
     output [31:0] O
 );
 wire [31:0] coreir_commonlib_mux2x32_inst0_out;
+wire [31:0] coreir_commonlib_mux2x32_inst0_in_data [1:0];
+assign coreir_commonlib_mux2x32_inst0_in_data[1] = I1;
+assign coreir_commonlib_mux2x32_inst0_in_data[0] = I0;
 commonlib_muxn__N2__width32 coreir_commonlib_mux2x32_inst0 (
-    .in_data_0(I0),
-    .in_data_1(I1),
+    .in_data(coreir_commonlib_mux2x32_inst0_in_data),
     .in_sel(S),
     .out(coreir_commonlib_mux2x32_inst0_out)
 );
@@ -121,7 +126,7 @@ Mux2xOutBits32 enable_mux (
 coreir_reg_arst #(
     .arst_posedge(1'b1),
     .clk_posedge(1'b1),
-    .init('h00000000),
+    .init(32'h00000000),
     .width(32)
 ) value (
     .clk(CLK),
@@ -139,9 +144,11 @@ module Mux2x32 (
     output [31:0] O
 );
 wire [31:0] coreir_commonlib_mux2x32_inst0_out;
+wire [31:0] coreir_commonlib_mux2x32_inst0_in_data [1:0];
+assign coreir_commonlib_mux2x32_inst0_in_data[1] = I1;
+assign coreir_commonlib_mux2x32_inst0_in_data[0] = I0;
 commonlib_muxn__N2__width32 coreir_commonlib_mux2x32_inst0 (
-    .in_data_0(I0),
-    .in_data_1(I1),
+    .in_data(coreir_commonlib_mux2x32_inst0_in_data),
     .in_sel(S),
     .out(coreir_commonlib_mux2x32_inst0_out)
 );
@@ -149,71 +156,18 @@ assign O = coreir_commonlib_mux2x32_inst0_out;
 endmodule
 
 module MuxWrapper_2_32 (
-    input [31:0] I_0,
-    input [31:0] I_1,
+    input [31:0] I [1:0],
     output [31:0] O,
     input [0:0] S
 );
 wire [31:0] Mux2x32_inst0_O;
 Mux2x32 Mux2x32_inst0 (
-    .I0(I_0),
-    .I1(I_1),
+    .I0(I[0]),
+    .I1(I[1]),
     .S(S[0]),
     .O(Mux2x32_inst0_O)
 );
 assign O = Mux2x32_inst0_O;
-endmodule
-
-module MuxWithDefaultWrapper_2_32_8_0 (
-    input [0:0] EN,
-    input [31:0] I_0,
-    input [31:0] I_1,
-    output [31:0] O,
-    input [7:0] S
-);
-wire [31:0] MuxWrapper_2_32_inst0_O;
-wire [31:0] MuxWrapper_2_32_inst1_O;
-wire and_inst0_out;
-wire [31:0] const_0_32_out;
-wire [7:0] const_2_8_out;
-wire coreir_ult8_inst0_out;
-MuxWrapper_2_32 MuxWrapper_2_32_inst0 (
-    .I_0(I_0),
-    .I_1(I_1),
-    .O(MuxWrapper_2_32_inst0_O),
-    .S(S[0])
-);
-MuxWrapper_2_32 MuxWrapper_2_32_inst1 (
-    .I_0(const_0_32_out),
-    .I_1(MuxWrapper_2_32_inst0_O),
-    .O(MuxWrapper_2_32_inst1_O),
-    .S(and_inst0_out)
-);
-corebit_and and_inst0 (
-    .in0(coreir_ult8_inst0_out),
-    .in1(EN[0]),
-    .out(and_inst0_out)
-);
-coreir_const #(
-    .value('h00000000),
-    .width(32)
-) const_0_32 (
-    .out(const_0_32_out)
-);
-coreir_const #(
-    .value(8'h02),
-    .width(8)
-) const_2_8 (
-    .out(const_2_8_out)
-);
-coreir_ult #(
-    .width(8)
-) coreir_ult8_inst0 (
-    .in0(S),
-    .in1(const_2_8_out),
-    .out(coreir_ult8_inst0_out)
-);
-assign O = MuxWrapper_2_32_inst1_O;
 endmodule
 
 module ConfigRegister_32_8_32_1 (
@@ -309,34 +263,45 @@ module DummyCore (
     output [31:0] read_config_data,
     input reset
 );
-wire [31:0] MuxWithDefaultWrapper_2_32_8_0_inst0_O;
-wire [31:0] dummy_1_O;
-wire [31:0] dummy_2_O;
-MuxWithDefaultWrapper_2_32_8_0 MuxWithDefaultWrapper_2_32_8_0_inst0 (
-    .EN(config_read),
-    .I_0(dummy_1_O),
-    .I_1(dummy_2_O),
-    .O(MuxWithDefaultWrapper_2_32_8_0_inst0_O),
-    .S(config_config_addr)
+wire [31:0] MuxWrapper_2_32_inst0_O;
+wire [31:0] config_reg_0_O;
+wire [31:0] config_reg_1_O;
+wire [31:0] dummy_1_inst0_O;
+wire [31:0] dummy_2_inst0_O;
+wire [31:0] MuxWrapper_2_32_inst0_I [1:0];
+assign MuxWrapper_2_32_inst0_I[1] = config_reg_1_O;
+assign MuxWrapper_2_32_inst0_I[0] = config_reg_0_O;
+MuxWrapper_2_32 MuxWrapper_2_32_inst0 (
+    .I(MuxWrapper_2_32_inst0_I),
+    .O(MuxWrapper_2_32_inst0_O),
+    .S(config_config_addr[0])
 );
-ConfigRegister_32_8_32_0 dummy_1 (
+ConfigRegister_32_8_32_0 config_reg_0 (
     .clk(clk),
     .reset(reset),
-    .O(dummy_1_O),
+    .O(config_reg_0_O),
     .config_addr(config_config_addr),
     .config_data(config_config_data),
     .config_en(config_write[0])
 );
-ConfigRegister_32_8_32_1 dummy_2 (
+ConfigRegister_32_8_32_1 config_reg_1 (
     .clk(clk),
     .reset(reset),
-    .O(dummy_2_O),
+    .O(config_reg_1_O),
     .config_addr(config_config_addr),
     .config_data(config_config_data),
     .config_en(config_write[0])
+);
+dummy_1 dummy_1_inst0 (
+    .I(config_reg_0_O),
+    .O(dummy_1_inst0_O)
+);
+dummy_2 dummy_2_inst0 (
+    .I(config_reg_1_O),
+    .O(dummy_2_inst0_O)
 );
 assign data_out_16b = data_in_16b;
 assign data_out_1b = data_in_1b;
-assign read_config_data = MuxWithDefaultWrapper_2_32_8_0_inst0_O;
+assign read_config_data = MuxWrapper_2_32_inst0_O;
 endmodule
 

--- a/tests/generator/test_instance_name.py
+++ b/tests/generator/test_instance_name.py
@@ -7,7 +7,8 @@ from gemstone.common.util import check_files_equal
 def test_instance_name_tile():
     core = DummyCore()
     circuit = core.circuit()
-    assert str(circuit.instances) == '[MuxWithDefaultWrapper_2_32_8_0_inst0 = MuxWithDefaultWrapper_2_32_8_0(), dummy_1 = ConfigRegister_32_8_32_0(name="dummy_1"), dummy_2 = ConfigRegister_32_8_32_1(name="dummy_2")]'  # noqa
+    print(str(circuit.instances))
+    assert str(circuit.instances) == '[config_reg_0 = ConfigRegister_32_8_32_0(name="config_reg_0"), dummy_1_inst0 = dummy_1(), config_reg_1 = ConfigRegister_32_8_32_1(name="config_reg_1"), dummy_2_inst0 = dummy_2(), MuxWrapper_2_32_inst0 = MuxWrapper_2_32()]'  # noqa
     with tempfile.TemporaryDirectory() as tempdir:
         m.compile(f"{tempdir}/core", circuit, output="coreir-verilog")
         assert check_files_equal(f"{tempdir}/core.v",


### PR DESCRIPTION
Better and more condensed register space
----
This PR introduces more condensed register space for garnet. This is one of the PRs that enables virtualization on CGRA.

## What it does:
1. Instead of allocating a register slot for every configuration register, it tries to pack as many as it can that fits `config_data_width`. 
2. To allow better debugging experience and backward compatibility, a `SliceWrapper` generator is introduced to slice the logical register value from the condensed config register. As a result, a logical config register can find its value in the waveform.

## Benefits:
1. Significantly reduce the bitstream size. By my rough calculation it is at least 2x reduction. This is very helpful for hardware virtualization as we can save storage space in the glb.
2. Config register area reduction. It reduces the MEM tile area by 3%. As a whole it is not a lot, but should help Pond to reduce the area overhead.

## Related PR:
https://github.com/StanfordAHA/garnet/pull/656
https://github.com/StanfordAHA/canal/pull/27

## Tests:
Since this is a cross-repo change, AHA flow test will not pass on this one. This whole flow tests is tested here:
https://github.com/StanfordAHA/aha/commit/6fad56debecbaeb501bce564c54cbf40d31ed948
which passes the whole flow test here:
https://buildkite.com/stanford-aha/aha-flow/builds/3030#6e774b31-7e6c-49a3-8ee0-94a2c573be0a