### PR TITLE
Set inline_single_instance to False for mux wrapper

### DIFF
--- a/gemstone/common/mux_wrapper_aoi.py
+++ b/gemstone/common/mux_wrapper_aoi.py
@@ -17,6 +17,7 @@ def _generate_mux_wrapper(height, width, mux_type: AOIMuxType):
 
     class _MuxWrapper(magma.Circuit):
         name = f"MuxWrapperAOIImpl_{height}_{width}"
+        coreir_metadata = {"inline_single_instance": False}
         in_height = max(1, height)
 
         ports = {


### PR DESCRIPTION
Depends on https://github.com/phanrahan/magma/pull/858

Prevents inline_single_instances from being run on the aoi mux wrapper.  Tested with `python garnet.py -v` now generates this:
```verilog
module MuxWrapperAOIImpl_2_16 (
    input [15:0] I [1:0],
    output [15:0] O,
    input [0:0] S
);
wire [15:0] mux_aoi_2_16_inst0_O;
mux_aoi_2_16 mux_aoi_2_16_inst0 (
    .I0(I[0]),
    .I1(I[1]),
    .S(S[0]),
    .O(mux_aoi_2_16_inst0_O)
);
assign O = mux_aoi_2_16_inst0_O;
endmodule
```
```verilog
wire [15:0] RMUX_T1_NORTH_B16_I [1:0];
assign RMUX_T1_NORTH_B16_I[1] = REG_T1_NORTH_B16_O;
assign RMUX_T1_NORTH_B16_I[0] = MUX_SB_T1_NORTH_SB_OUT_B16_O;
MuxWrapperAOIImpl_2_16 RMUX_T1_NORTH_B16 (
    .I(RMUX_T1_NORTH_B16_I),
    .O(RMUX_T1_NORTH_B16_O),
    .S(RMUX_T1_NORTH_B16_sel_inst0_O)
);
RMUX_T1_NORTH_B16_sel RMUX_T1_NORTH_B16_sel_inst0 (
    .I(config_reg_0_O),
    .O(RMUX_T1_NORTH_B16_sel_inst0_O)
);
```

rather than

``` verilog
mux_aoi_2_16 RMUX_T1_NORTH_B16$mux_aoi_2_16_inst0 (
    .I0(MUX_SB_T1_NORTH_SB_OUT_B16$mux_aoi_4_16_inst0_O),
    .I1(REG_T1_NORTH_B16_O),
    .S(RMUX_T1_NORTH_B16_sel_inst0_O[0]),
    .O(RMUX_T1_NORTH_B16$mux_aoi_2_16_inst0_O)
);
RMUX_T1_NORTH_B16_sel RMUX_T1_NORTH_B16_sel_inst0 (
    .I(config_reg_0_O),
    .O(RMUX_T1_NORTH_B16_sel_inst0_O)
);
```